### PR TITLE
Refactor/prop types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.0",

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -3,7 +3,7 @@
 }
 
 .poster {
-    height: 200px;
+    height: 300px;
     border: solid black 1px;
     box-shadow: 5px 5px 10px 5px rgb(43, 41, 41);
 }
@@ -20,6 +20,13 @@
     align-items: center;
     font-weight: bold;
     margin: 0px 10px 20px 0px;
+}
+
+.poster-title {
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 h4 {

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -12,7 +12,7 @@ const Card = ({ id, poster_path, title, rating }) => {
     
     return (
         <div className='card'>
-            <h3>{title}</h3>
+            <h3 className='poster-title'>{title}</h3>
             <Link to={`/${id}`}><img src={poster_path} alt={title} className="poster"></img></Link>
             <section className="section-rating">
                 <img src={ratingImage} alt={ratingAltText} className="image-rating"></img>

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -2,9 +2,10 @@ import React from 'react';
 import rotten from '../../images/spoiled-tomatillo.png'
 import good from '../../images/ripe-tomatillo.png'
 import './Card.css';
+import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
-const Card = ({ id, poster_path, title, rating, displayDetails }) => {
+const Card = ({ id, poster_path, title, rating }) => {
 
     let ratingImage = rating < 6 ? rotten : good;
     let ratingAltText = rating < 6 ? 'rotten tomatillo' : 'fresh tomatillo'
@@ -22,3 +23,10 @@ const Card = ({ id, poster_path, title, rating, displayDetails }) => {
 }
 
 export default Card
+
+Card.propTypes = {
+    id: PropTypes.number,
+    poster_path: PropTypes.string,
+    title: PropTypes.string,
+    rating: PropTypes.number
+}

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -25,8 +25,8 @@ const Card = ({ id, poster_path, title, rating }) => {
 export default Card
 
 Card.propTypes = {
-    id: PropTypes.number,
-    poster_path: PropTypes.string,
-    title: PropTypes.string,
-    rating: PropTypes.number
+    id: PropTypes.number.isRequired,
+    poster_path: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    rating: PropTypes.number.isRequired
 }

--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -3,6 +3,7 @@ import fetchData from '../../apiCalls.js'
 import './Details.css'
 import Error from '../Error/Error.js';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types'
 
 class Details extends Component {
   constructor(props) {
@@ -39,8 +40,8 @@ class Details extends Component {
       height: "750px",
     }
     return (
-      <div className='main-details' aria-opened={this.state.detailsOpen} style={styles}>
-      {this.state.showError && <Error closeError={this.props.closeError}/>}
+      <div className='main-details' aria-expanded={this.state.detailsOpen} style={styles}>
+      {this.state.showError && <Error key={this.props.id} closeError={this.props.closeError}/>}
         <div className='overlay'></div>
         <div className='details-container'>
           <img className='poster-img' name='posterPath' src={details['poster_path']} alt={`${details.title} poster image`}></img>
@@ -63,3 +64,9 @@ class Details extends Component {
 }
 
 export default Details
+
+Details.propTypes = {
+  id: PropTypes.number,
+  closeError: PropTypes.func,
+  key: PropTypes.number
+}

--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -30,8 +30,8 @@ class Details extends Component {
   
   render () {
     const details = this.state.movieDetails
-    const buttons = Object.keys(details).length && details.genres.map(genre => {
-      return <button className='genre'>{genre}</button>
+    const buttons = Object.keys(details).length && details.genres.map((genre, index) => {
+      return <button key={index} className='genre'>{genre}</button>
     })
     const styles = {
       backgroundImage: `url(${details['backdrop_path']})`,
@@ -41,7 +41,7 @@ class Details extends Component {
     }
     return (
       <div className='main-details' aria-expanded={this.state.detailsOpen} style={styles}>
-      {this.state.showError && <Error key={this.props.id} closeError={this.props.closeError}/>}
+      {this.state.showError && <Error closeError={this.props.closeError}/>}
         <div className='overlay'></div>
         <div className='details-container'>
           <img className='poster-img' name='posterPath' src={details['poster_path']} alt={`${details.title} poster image`}></img>

--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -66,7 +66,6 @@ class Details extends Component {
 export default Details
 
 Details.propTypes = {
-  id: PropTypes.number,
-  closeError: PropTypes.func,
-  key: PropTypes.number
+  id: PropTypes.number.isRequired,
+  closeError: PropTypes.func.isRequired
 }

--- a/src/components/Error/Error.js
+++ b/src/components/Error/Error.js
@@ -2,6 +2,7 @@ import React from "react";
 import './Error.css'
 import errorIcon from '../../images/alert-icon.png';
 import { Link } from 'react-router-dom';
+import PropType from 'prop-types'
 
 const Error = ( { closeError }) => {
   return (
@@ -19,3 +20,7 @@ const Error = ( { closeError }) => {
 }
 
 export default Error
+
+Error.propType = {
+  closeError: PropType.func
+}

--- a/src/components/Error/Error.js
+++ b/src/components/Error/Error.js
@@ -22,5 +22,5 @@ const Error = ( { closeError }) => {
 export default Error
 
 Error.propType = {
-  closeError: PropType.func
+  closeError: PropType.func.isRequired
 }

--- a/src/components/MoviesCardsContainer/MoviesCardsContainer.js
+++ b/src/components/MoviesCardsContainer/MoviesCardsContainer.js
@@ -36,9 +36,9 @@ const MoviesCardsContainer = ({ allMovieData, sortByTitle, sortByTitlePressed, s
 export default MoviesCardsContainer
 
 MoviesCardsContainer.propTypes = {
-    allMovieData: PropTypes.array,
-    sortByTitle: PropTypes.func,
-    sortByRating: PropTypes.func,
+    allMovieData: PropTypes.array.isRequired,
+    sortByTitle: PropTypes.func.isRequired,
+    sortByRating: PropTypes.func.isRequired,
     sortByTitlePressed: PropTypes.bool,
     sortByRatingPressed: PropTypes.bool 
 }

--- a/src/components/MoviesCardsContainer/MoviesCardsContainer.js
+++ b/src/components/MoviesCardsContainer/MoviesCardsContainer.js
@@ -22,8 +22,8 @@ const MoviesCardsContainer = ({ allMovieData, sortByTitle, sortByTitlePressed, s
             <div className="sort">
                 <p className="sort-by">Sort by:</p>
                 <div className="sortButtons">
-                    <button className={sortByTitlePressed ? 'pressed' : undefined} onClick={() => sortByTitle(allMovieData)} aria-pressed={sortByTitlePressed}>Title (A-Z)</button>
-                    <button className={sortByRatingPressed ? 'pressed' : undefined} onClick={() => sortByRating(allMovieData)} aria-pressed={sortByRatingPressed}>Rating (Descending)</button>
+                    <button className={sortByTitlePressed ? 'pressed' : 'sort-button-title'} onClick={() => sortByTitle(allMovieData)} aria-pressed={sortByTitlePressed}>Title (A-Z)</button>
+                    <button className={sortByRatingPressed ? 'pressed' : 'sort-button-rating'} onClick={() => sortByRating(allMovieData)} aria-pressed={sortByRatingPressed}>Rating (Descending)</button>
                 </div>
             </div>
             <div className="MoviesCardsContainer">

--- a/src/components/MoviesCardsContainer/MoviesCardsContainer.js
+++ b/src/components/MoviesCardsContainer/MoviesCardsContainer.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import Card from '../Card/Card.js';
+import PropTypes from 'prop-types'
 import './MoviesCardsContainer.css';
 
-const MoviesCardsContainer = ({ allMovieData, displayDetails, sortByTitle, sortByTitlePressed, sortByRating, sortByRatingPressed }) => {
+const MoviesCardsContainer = ({ allMovieData, sortByTitle, sortByTitlePressed, sortByRating, sortByRatingPressed }) => {
     const allCards = allMovieData.map(movie => {
         return (
             <Card
@@ -11,7 +12,6 @@ const MoviesCardsContainer = ({ allMovieData, displayDetails, sortByTitle, sortB
                 poster_path={movie.posterPath}
                 title={movie.title}
                 rating={movie.rating}
-                displayDetails={displayDetails}
             />
         )
     })
@@ -22,8 +22,8 @@ const MoviesCardsContainer = ({ allMovieData, displayDetails, sortByTitle, sortB
             <div className="sort">
                 <p className="sort-by">Sort by:</p>
                 <div className="sortButtons">
-                    <button className={sortByTitlePressed && 'pressed'} onClick={() => sortByTitle(allMovieData)} aria-pressed={sortByTitlePressed}>Title (A-Z)</button>
-                    <button className={sortByRatingPressed && 'pressed'} onClick={() => sortByRating(allMovieData)} aria-pressed={sortByRatingPressed}>Rating (Descending)</button>
+                    <button className={sortByTitlePressed ? 'pressed' : undefined} onClick={() => sortByTitle(allMovieData)} aria-pressed={sortByTitlePressed}>Title (A-Z)</button>
+                    <button className={sortByRatingPressed ? 'pressed' : undefined} onClick={() => sortByRating(allMovieData)} aria-pressed={sortByRatingPressed}>Rating (Descending)</button>
                 </div>
             </div>
             <div className="MoviesCardsContainer">
@@ -34,3 +34,11 @@ const MoviesCardsContainer = ({ allMovieData, displayDetails, sortByTitle, sortB
 }
 
 export default MoviesCardsContainer
+
+MoviesCardsContainer.propTypes = {
+    allMovieData: PropTypes.array,
+    sortByTitle: PropTypes.func,
+    sortByRating: PropTypes.func,
+    sortByTitlePressed: PropTypes.bool,
+    sortByRatingPressed: PropTypes.bool 
+}


### PR DESCRIPTION
This branch adds propType validation to:
- `Details`
- `MovieCardsContainer`
- `Card`
- `Error`
This adds required validation to the places that need the proptype to render correctly. I'm still wrapping my brain around `.isRequired` propTypes and where exactly we need them so I would love if that could be checked in review.

This branch also changes one aria tag that was throwing an error. It was changed from `opened` to `expanded`.

This branch also had to refactor our conditional render of the sorting buttons. The console threw an error when it was formatted with `&&` and suggested we use a ternary so I switched it (see line 25 and 26 on `MovieCardsContainer`